### PR TITLE
HTTPS and private feed support

### DIFF
--- a/eeml/__init__.py
+++ b/eeml/__init__.py
@@ -23,7 +23,7 @@ class Environment(object):
     """
 
     def __init__(self, title=None, feed=None, status=None, description=None,
-                 icon=None, website=None, email=None, updated=None, creator=None, id=None):
+                 icon=None, website=None, email=None, updated=None, creator=None, id=None, private=None):
         """
         Create a new `Environment`.
 
@@ -68,6 +68,7 @@ class Environment(object):
         self._id = id
         self._location = None
         self._data = {}
+        self._private = private
 
     def setLocation(self, location):
         """
@@ -135,6 +136,10 @@ class Environment(object):
         if self._email:
             tmp = doc.createElement('email')
             tmp.appendChild(doc.createTextNode(self._email))
+            env.appendChild(tmp)
+        if self._private is not None:
+            tmp = doc.createElement('private')
+            tmp.appendChild(doc.createTextNode(str(self._private).lower()))
             env.appendChild(tmp)
         if self._location:            
             env.appendChild(self._location.toeeml())

--- a/eeml/datastream.py
+++ b/eeml/datastream.py
@@ -17,7 +17,9 @@ class Pachube(object):
     A class for manually updating a pachube data stream.
     """
 
-    def __init__(self, url, key):
+    host = 'api.pachube.com'
+
+    def __init__(self, url, key, use_https=True):
         """
         :param url: the api url either '/v2/feeds/1275.xml' or 1275
         :type url: `str`
@@ -38,6 +40,7 @@ class Pachube(object):
             except TypeError:
                 raise TypeError("The url argument has to be in the form '/v2/feeds/1275.xml' or 1275")
         self._key = key
+        self._use_https = use_https
         self._eeml = eeml.create_eeml(eeml.Environment(), None, [])
 
     def update(self, data):
@@ -55,7 +58,8 @@ class Pachube(object):
 
         :raise Exception: if there was problem with the communication
         """
-        conn = httplib.HTTPConnection('api.pachube.com:80')
+        conn = httplib.HTTPSConnection(self.host) if self._use_https else \
+                httplib.HTTPConnection(self.host)
         conn.request('PUT', self._url, self._eeml.toeeml().toxml(), {'X-PachubeApiKey': self._key})
         resp = conn.getresponse()
         if resp.status != 200:


### PR DESCRIPTION
Use HTTPS by default, and allow "private" attribute to be specified for the feed
