### PR TITLE
Tweaks for setup.py consistancy

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include *.txt
+include *.rst

--- a/eeml/__init__.py
+++ b/eeml/__init__.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 
 from datetime import date, datetime
-from lxml import etree
+
+try:
+    from lxml import etree
+except ImportError: # If lxml is not there try python standard lib
+    from xml.etree import ElementTree as etree
+
 from datastream import *
 
 __authors__ = "Peter Vizi"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[nosetests]
+where = tests

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import logging, multiprocessing
 
 setup(
     name="python-eeml", 
-    version="1.1.0",
+    version="1.1.1",
     author="Peter Vizi",
     author_email="peter.vizi@gmail.com",
     url="https://github.com/petervizi/python-eeml",

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     description="Python support for the Extended Environments Markup Language",
     license="GPLv3",
     install_requires = [
+        'lxml',
     ],
     test_suite = 'nose.collector',
     tests_require = [

--- a/tests/test_eeml.py
+++ b/tests/test_eeml.py
@@ -21,7 +21,7 @@ class TestEEML(TestCase):
             <lon>22.7</lon>
             <ele>0.2</ele>
             </location>
-            """.strip()), loc.toeeml()))
+            """.strip()), loc.toeeml(), reporter=self.fail))
 
 
     def test_good_unit(self):
@@ -30,7 +30,7 @@ class TestEEML(TestCase):
         assert_true(xml_compare(etree.fromstring(
             """
             <unit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.eeml.org/xsd/0.5.1" type="basicSI" symbol="C">Celzius</unit>
-            """.strip()), unit.toeeml()))
+            """.strip()), unit.toeeml(), reporter=self.fail))
 
 
     def test_good_data(self):
@@ -50,7 +50,7 @@ class TestEEML(TestCase):
             <current_value maxValue="100" minValue="0">10.0</current_value>
             <unit symbol="C" type="derivedSI">Celsius</unit>
             </data>
-            """.strip()), test_data.toeeml()))
+            """.strip()), test_data.toeeml(), reporter=self.fail))
 
 
     def test_good_environment(self):
@@ -75,7 +75,7 @@ class TestEEML(TestCase):
                 <icon>http://www.roomsomewhere/icon.png</icon>
                 <website>http://www.roomsomewhere/</website>
                 <email>myemail@roomsomewhere</email>
-            </environment>""".strip()), env.toeeml()))
+            </environment>""".strip()), env.toeeml(), reporter=self.fail))
 
     def test_good_create_doc(self):
         env = Environment('A Room Somewhere',


### PR DESCRIPTION
Hi Peter,

I tweaked some of the set-up files for consistency as you changed from Python standard lib. to lxml.
- lxml is now a pre-req for installation and manifest added.
- I added a small backup plan if importing lxml fails that will import the python standard lib xml.etree instead.
- Verbosity to xml_compare calls to ensure proper failing of the test if issue.
- Version bump to 1.1.1 from 1.1.0

Confirmed all tests passed prior to pull-req.
